### PR TITLE
Fixed Deployment API version

### DIFF
--- a/helm-charts/tt-rss/templates/deployment.yaml
+++ b/helm-charts/tt-rss/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "tt-rss.fullname" . }}


### PR DESCRIPTION
Deployment apps/v1beta2 API has been deprecated in Kubernetes 1.16. 
Reference: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
